### PR TITLE
Make gzip optional for e2e test contracts

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -3,14 +3,26 @@ package e2e
 import (
 	"flag"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
-var wasmContractPath string
+var (
+	wasmContractPath    string
+	wasmContractGZipped bool
+)
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&wasmContractPath, "contracts-path", "testdata", "Set path to dir with gzipped wasm contracts")
+	flag.BoolVar(&wasmContractGZipped, "gzipped", true, "Use `.gz` file ending when set")
 	flag.Parse()
 
 	os.Exit(m.Run())
+}
+
+func buildPathToWasm(fileName string) string {
+	if wasmContractGZipped {
+		fileName += ".gz"
+	}
+	return filepath.Join(wasmContractPath, fileName)
 }


### PR DESCRIPTION
This makes it easier to use the e2e tests. Default is gzipped
Example:
```sh
 go test ./... -gzipped=false
```