### PR TITLE
chore: makefile build flag parametrization

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -94,7 +94,7 @@ build-linux-static:
 	rm -rf vendor/
 
 install:
-	go install -mod=readonly $(BUILD_FLAGS) ./cmd/$(APPNAME)
+	go install -mod=readonly $(BUILD_FLAGS) ./cmd/meshd
 
 ########################################
 ### Testing

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -47,13 +47,14 @@ comma := ,
 build_tags_comma_sep := $(subst $(empty),$(comma),$(build_tags))
 
 # process linker flags
-name := mesh
-appName := meshd
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(name) \
-		  -X github.com/cosmos/cosmos-sdk/version.AppName=$(appName) \
+NAME := mesh
+APPNAME := meshd
+PREFIX := mesh
+ldflags := -X github.com/cosmos/cosmos-sdk/version.Name=$(NAME) \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=$(APPNAME) \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X github.com/osmosis-labs/mesh-security-sdk/demo/app.Bech32Prefix=$(name) \
+		  -X github.com/osmosis-labs/mesh-security-sdk/demo/app.Bech32Prefix=$(PREFIX) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 ifeq ($(WITH_CLEVELDB),yes)
@@ -77,11 +78,11 @@ ifeq ($(OS),Windows_NT)
 	$(error mesh demo server not supported)
 	exit 1
 else
-	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILD_DIR)/meshd ./cmd/meshd
+	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
 endif
 
 build-vendored:
-	go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/meshd ./cmd/meshd
+	echo go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
 
 build-linux-static:
 	go mod vendor  # quick hack to make local dependencies work in Docker
@@ -93,7 +94,7 @@ build-linux-static:
 	rm -rf vendor/
 
 install:
-	go install -mod=readonly $(BUILD_FLAGS) ./cmd/meshd
+	go install -mod=readonly $(BUILD_FLAGS) ./cmd/$(APPNAME)
 
 ########################################
 ### Testing

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -78,11 +78,11 @@ ifeq ($(OS),Windows_NT)
 	$(error mesh demo server not supported)
 	exit 1
 else
-	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
+	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/meshd
 endif
 
 build-vendored:
-	go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
+	go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/meshd
 
 build-linux-static:
 	go mod vendor  # quick hack to make local dependencies work in Docker

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -47,12 +47,13 @@ comma := ,
 build_tags_comma_sep := $(subst $(empty),$(comma),$(build_tags))
 
 # process linker flags
-
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=mesh \
-		  -X github.com/cosmos/cosmos-sdk/version.AppName=meshd \
+name := mesh
+appName := meshd
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(name) \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=$(appName) \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X github.com/osmosis-labs/mesh-security-sdk/demo/app.Bech32Prefix=mesh \
+		  -X github.com/osmosis-labs/mesh-security-sdk/demo/app.Bech32Prefix=$(name) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 ifeq ($(WITH_CLEVELDB),yes)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -82,7 +82,7 @@ else
 endif
 
 build-vendored:
-	echo go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
+	go build -mod=vendor $(BUILD_FLAGS) -o $(BUILD_DIR)/$(APPNAME) ./cmd/$(APPNAME)
 
 build-linux-static:
 	go mod vendor  # quick hack to make local dependencies work in Docker


### PR DESCRIPTION
## Overview
We are using the mesh-security-infra repo as a base to create dummy osmosis and juno chain binary. This is used for testing and more realistic integration for the frontend and the devnet.

Just need to parametrized the build flags, so we can use the same Makefile command in another `Dockerfile`

Example: 
* https://github.com/osmosis-labs/mesh-security-infra/blob/main/docker/Dockerfile.osmosis#L22
* https://github.com/osmosis-labs/mesh-security-infra/blob/main/docker/Dockerfile.juno#L22