### PR TITLE
docs: fix dead links

### DIFF
--- a/x/meshsecurity/README.md
+++ b/x/meshsecurity/README.md
@@ -8,7 +8,7 @@ Projects that want to integrate the meshsecurity module onto their Cosmos SDK ch
 - [x/staking](https://github.com/cosmos/cosmos-sdk/tree/main/x/staking)
 - [x/auth](https://github.com/cosmos/cosmos-sdk/tree/main/x/auth)
 - [x/bank](https://github.com/cosmos/cosmos-sdk/tree/main/x/bank)
-- [x/wasm](github.com/CosmWasm/wasmd/x/wasm)
+- [x/wasm](https://github.com/CosmWasm/wasmd/tree/main/x/wasm)
 
 ## Configuring and Adding Module
 1. Add the mesh security package to the go.mod and install it.

--- a/x/meshsecurityprovider/README.md
+++ b/x/meshsecurityprovider/README.md
@@ -8,7 +8,7 @@ Projects that want to integrate the meshsecurityprovider module onto their Cosmo
 - [x/staking](https://github.com/cosmos/cosmos-sdk/tree/main/x/staking)
 - [x/auth](https://github.com/cosmos/cosmos-sdk/tree/main/x/auth)
 - [x/bank](https://github.com/cosmos/cosmos-sdk/tree/main/x/bank)
-- [x/wasm](github.com/CosmWasm/wasmd/x/wasm)
+- [x/wasm](https://github.com/CosmWasm/wasmd/tree/main/x/wasm)
 
 ## Configuring and Adding Module
 1. Add the mesh security package to the go.mod and install it.

--- a/x/setup_mesh.md
+++ b/x/setup_mesh.md
@@ -2,7 +2,7 @@
 This document describes about how to deploy and setup mesh security for cosmos chains
 
 ## Consumer chain
-1. Integrate `meshsecurity` module by this [guide](./x/meshsecurity/README.md).
+1. Integrate `meshsecurity` module by this [guide](./meshsecurity/README.md).
 2. Deploy price feed contract:
 - Store code file `mesh_simple_price_feed.wasm`
 - Instantiate contract with parameters: `{"native_per_foreign": $token_ratio}`
@@ -21,7 +21,7 @@ type MsgSetVirtualStakingMaxCap struct {
 }
 ```
 ## Provider chain
-1. Integrate `meshsecurityprovider` module by this [guide](./x/meshsecurityprovider/README.md).
+1. Integrate `meshsecurityprovider` module by this [guide](./meshsecurityprovider/README.md).
 2. Store contract codes:
 - `mesh_vault.wasm`
 - `mesh_native_staking_proxy.wasm`


### PR DESCRIPTION
Hi! I fixed multiple broken links in `README.md` and `setup_mesh.md` that were either missing proper URL formatting or incorrect paths.
